### PR TITLE
rough support for new 2021 model grid

### DIFF
--- a/src/monome.js
+++ b/src/monome.js
@@ -1,22 +1,49 @@
 import {
+  log,
   err,
   ERR_WRITE,
   ERR_WRITE_MISSING_BYTES,
   USB_XFER_STATUS_OK,
 } from './utils.js';
 
+import { getInterfaceForVendor } from './webmonome.js';
+
 export default class Monome {
   constructor(device) {
     this.device = device;
     this.callbacks = {};
+
+    // set i/o based on chosen interface endpoints
+    // TODO: cleanup :'(
+    try {
+      this.device.configuration.interfaces[
+        getInterfaceForVendor(device.vendorId)
+      ].alternates[0].endpoints.forEach(({ direction, endpointNumber }) => {
+        if (direction === 'in' && this.endpointIn === undefined) {
+          this.endpointIn = endpointNumber;
+        } else if (direction === 'out' && this.endpointOut === undefined) {
+          this.endpointOut = endpointNumber;
+        }
+      });
+    } catch (e) {
+      log(e, 2);
+    }
+
+    // if unabled to dynmically set, we can try semi-sensible defaults
+    this.endpointIn = this.endpointIn === undefined ? 1 : this.endpointIn;
+    this.endpointOut = this.endpointOut === undefined ? 2 : this.endpointOut;
   }
 
   async listen() {
     if (!this.isConnected) return;
     const result = await this.read(64);
 
-    if (result.status === 'ok' && result.data.byteLength > 2) {
-      this.processData(result.data, 2);
+    // TODO: did i have a reason for skipping the first two bytes here?
+    // seems older mext send noisey bytes that i was skipping. 2021 devices
+    // run "silent" and skipping bytes breaks everything
+    // not skipping seems to still work fine for older mext
+    if (result.status === 'ok' && result.data.byteLength > 0) {
+      this.processData(result.data, 0);
     }
 
     await this.listen();
@@ -24,12 +51,12 @@ export default class Monome {
 
   async read(byteLength) {
     if (!this.isConnected) return;
-    return this.device.transferIn(1, byteLength);
+    return this.device.transferIn(this.endpointIn, byteLength);
   }
 
   async write(data) {
     const buffer = new Uint8Array(data);
-    const result = await this.device.transferOut(2, buffer);
+    const result = await this.device.transferOut(this.endpointOut, buffer);
     if (result.status !== USB_XFER_STATUS_OK) err(ERR_WRITE);
     if (result.bytesWritten !== buffer.byteLength) err(ERR_WRITE_MISSING_BYTES);
     return result;

--- a/src/webmonome.js
+++ b/src/webmonome.js
@@ -3,7 +3,18 @@ import Series from './series.js';
 import { log, err, WARN_NO_USB, ERR_NOT_SUPPORTED } from './utils.js';
 
 /* monome usb vendor id */
-const VENDOR_ID = 0x0403;
+const VENDOR_ID_GENESIS = 0x0403;
+const VENDOR_ID_2021 = 0x0483;
+
+// based on personal observation, unsure if there is a
+// a dynamic way to determine these (right now, i just
+// know from exp that 2021 devices have to claim interface
+// 1 instead of 0)
+const interfaceMap = {
+  [VENDOR_ID_GENESIS]: 0,
+  [VENDOR_ID_2021]: 1,
+};
+export const getInterfaceForVendor = vendorId => interfaceMap[vendorId] || 0;
 
 /* check for support */
 const hasUsb = 'navigator' in window && 'usb' in navigator;
@@ -15,11 +26,14 @@ export default {
     let device;
     try {
       device = await navigator.usb.requestDevice({
-        filters: [{ vendorId: VENDOR_ID }],
+        filters: [
+          { vendorId: VENDOR_ID_GENESIS },
+          { vendorId: VENDOR_ID_2021 },
+        ],
       });
       await device.open();
       if (device.configuration === null) await device.selectConfiguration(1);
-      await device.claimInterface(0);
+      await device.claimInterface(getInterfaceForVendor(device.vendorId));
       const monome = factory(device);
       monome.listen();
       return monome;
@@ -27,8 +41,8 @@ export default {
       device = null;
       throw e;
     }
-  }
-}
+  },
+};
 
 function factory(device) {
   const Klass = {


### PR DESCRIPTION
- queries new vendor id for 2021 grids
- dynamically handles new interfaces and endpoints 2021 grids