### PR TITLE
Make it easier to install from a Git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "rollup -c",
     "precommit": "lint-staged",
     "dev": "rollup -c -w",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "pretty": "npm run pretty-src -- \"src/**/*.js\" && npm run pretty-pkg",
     "pretty-pkg": "prettier-package-json --write ./package.json",
     "pretty-src": "prettier --write"


### PR DESCRIPTION
This PR moves the `prepublishOnly` build script to `prepare`. This command is run after installation, and so enables the package to be installed from a Git repo