### PR TITLE
Standardise Event System

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ system responses come in the form of events (see below), but this may be changed
 - subscribe to events:
 
   ```javascript
-  monome.on(eventName, callback)
+  monome.addEventListener(eventName, callback)
   ```
   - `eventName`: string
   - `callback`: function
@@ -235,7 +235,7 @@ system responses come in the form of events (see below), but this may be changed
 - unsubscribe from events:
 
   ```javascript
-  monome.off(eventName, callback)
+  monome.removeEventListener(eventName, callback)
   ```
   - `eventName`: string
   - `callback`: function

--- a/demo/basic.html
+++ b/demo/basic.html
@@ -65,14 +65,14 @@
         document.querySelector(`[value=x${x}y${y}]`).checked = checked
       }
 
-      const keydown = e => {
-        monome.gridLed(e.x, e.y, true);
-        check(e.x, e.y, true);
+      const keydown = ({ detail: { x, y } }) => {
+        monome.gridLed(x, y, true);
+        check(x, y, true);
       };
 
-      const keyup = e => {
-        monome.gridLed(e.x, e.y);
-        check(e.x, e.y);
+      const keyup = ({ detail: { x, y } }) => {
+        monome.gridLed(x, y);
+        check(x, y);
       };
 
       const logEvent = e => {
@@ -80,12 +80,12 @@
       };
 
       function setup () {
-        monome.on('gridKeyDown', keydown);
-        monome.on('gridKeyUp', keyup);
-        monome.on('query', logEvent);
-        monome.on('getId', logEvent);
-        monome.on('getGridOffsets', logEvent);
-        monome.on('getGridSize', logEvent);
+        monome.addEventListener('gridKeyDown', keydown);
+        monome.addEventListener('gridKeyUp', keyup);
+        monome.addEventListener('query', logEvent);
+        monome.addEventListener('getId', logEvent);
+        monome.addEventListener('getGridOffsets', logEvent);
+        monome.addEventListener('getGridSize', logEvent);
       }
     </script>
   </body>

--- a/src/monome.js
+++ b/src/monome.js
@@ -8,8 +8,9 @@ import {
 
 import { getInterfaceForVendor } from './webmonome.js';
 
-export default class Monome {
+export default class Monome extends EventTarget {
   constructor(device) {
+    super();
     this.device = device;
     this.callbacks = {};
 
@@ -50,45 +51,10 @@ export default class Monome {
     return Boolean(this.device && this.device.opened);
   }
 
-  on(eventName, fn) {
-    if (typeof fn !== 'function') return;
-    (this.callbacks[eventName] = this.callbacks[eventName] || []).push(fn);
-  }
-
-  off(eventName, fn) {
-    if (arguments.length === 0) {
-      this.callbacks = {};
-      return;
-    }
-
-    const cbs = this.callbacks[eventName];
-    if (!cbs) return;
-
-    if (arguments.length === 1) {
-      delete this.callbacks[eventName];
-      return;
-    }
-
-    for (let i = 0; i < cbs.length; i++) {
-      if (cbs[i] === fn) {
-        cbs.splice(i, 1);
-        break;
-      }
-    }
-
-    if (cbs.length === 0) {
-      delete this.callbacks[eventName];
-    }
-  }
-
-  emit(name, payload) {
-    const cbs = this.callbacks[name];
-    if (!Array.isArray(cbs)) return;
-    for (let i = 0; i < cbs.length; i++) {
-      const fn = cbs[i];
-      if (typeof fn !== 'function') skip;
-      fn(payload);
-    }
+  emit(eventName, payload) {
+    const event = new CustomEvent(eventName, { detail: payload })
+    this.dispatchEvent(event);
+    return event;
   }
 }
 


### PR DESCRIPTION
This pull request standardises the event system in accordance with other Web APIs. The standardisation could enable the creation of grid-like devices with an identical API, without the need to duplicate or adapt the event system.

For example, let's say we created a grid-like device that used qwerty input. We can use the standard `addEventListener` to create apps that work with this grid-like device, as well as webmonome.